### PR TITLE
[ADD] shared_data option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,12 @@ module).
       PATH:  migration file or directory of migration files.
 
       Migration file must end with .py extension and must have 'migrate' function
-      that expects 'env' argument.
+      that expects 'env' and 'shared_data' argument.
+
+      'shared_data' argument is a dictionary that collects previous
+      migration scripts returned values (key is migration script name).
+      If return (of 'migrate' function) is None, it is not included in
+      shared_data.
 
     Options:
       -c, --config FILE          Specify the Odoo configuration file. Other ways

--- a/tests/data/mig1/2022-02-19-partners-companies.py
+++ b/tests/data/mig1/2022-02-19-partners-companies.py
@@ -1,4 +1,4 @@
-def migrate(env):
+def migrate(env, shared_data):
     ResPartner = env['res.partner']
     ResPartner.create([{'name': 'mig-partner-111'}, {'name': 'mig-partner-222'}])
     env.cr.execute(

--- a/tests/data/mig1/2022-02-20-titles.py
+++ b/tests/data/mig1/2022-02-20-titles.py
@@ -1,3 +1,3 @@
-def migrate(env):
+def migrate(env, shared_data):
     env['res.partner.title'].create({'name': 'mig-title-111'})
     env.ref("base.res_partner_title_doctor").name = 'mig-title-222'

--- a/tests/data/mig2/2022-02-01-partner-categories.py
+++ b/tests/data/mig2/2022-02-01-partner-categories.py
@@ -1,3 +1,3 @@
-def migrate(env):
+def migrate(env, shared_data):
     # Change from "Services" name.
     env.ref('base.res_partner_category_11').name = 'mig-services-111'

--- a/tests/data/mig3/01-partner-parent.py
+++ b/tests/data/mig3/01-partner-parent.py
@@ -1,0 +1,5 @@
+def migrate(env, shared_data):
+    partner = env["res.partner"].create(
+        {"name": "mig-partner-parent-111", "is_company": True}
+    )
+    return partner.id

--- a/tests/data/mig3/02-partner-contact.py
+++ b/tests/data/mig3/02-partner-contact.py
@@ -1,0 +1,10 @@
+def migrate(env, shared_data):
+    parent_id = shared_data["01-partner-parent"]
+    contact = env["res.partner"].create(
+        {
+            "name": "mig-partner-contact-222",
+            "is_company": False,
+            "parent_id": parent_id
+        }
+    )
+    return contact.id

--- a/tests/data/mig3/03-partner-country.py
+++ b/tests/data/mig3/03-partner-country.py
@@ -1,0 +1,4 @@
+def migrate(env, shared_data):
+    partner_ids = [shared_data['01-partner-parent'], shared_data['02-partner-contact']]
+    country_id = env.ref('base.lt')
+    env['res.partner'].browse(partner_ids).write({'country_id': country_id})


### PR DESCRIPTION
Now migration scripts must have extra argument, 'shared_data', which is a dictionary that stores previous migration return results (if there was any).

This way we can split migration scripts into smaller ones and share data between it, instead of writing one big migration script that is isolated.

Important notice. If script depends on other migration script and that script is already run, these scripts must be force run together, to make sure it won't fail.